### PR TITLE
logs: Add the default logs to the stack

### DIFF
--- a/ansible/magento.yml
+++ b/ansible/magento.yml
@@ -26,6 +26,7 @@
 
     # - {role: cycloid.postfix, tags: postfix}
     # require ses login/pass but install postfix
+    - {role: cycloid.fluentd, tags: fluentd}
     - {role: cycloid.php, tags: php}
     - {role: jdauphant.nginx, tags: nginx}
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -13,6 +13,11 @@
   name: cycloid.deployment
   scm: git
 
+- src: git@github.com:cycloidio/ansible-fluentd.git
+  version: master
+  name: cycloid.fluentd
+  scm: git
+
 # FIXME : Remove this if we don't use EFS
 # - src: git@github.com:cycloidio/ansible-systemd
 #   version: master

--- a/terraform/module-magento/front.tf
+++ b/terraform/module-magento/front.tf
@@ -54,7 +54,7 @@ resource "aws_instance" "front" {
   ami                         = "${data.aws_ami.debian_jessie.id}"
   # associate_public_ip_address = false
   count                       = "${var.front_count}"
-  # iam_instance_profile        = "${aws_iam_instance_profile.front_profile.name}"
+  iam_instance_profile        = "${aws_iam_instance_profile.front_profile.name}"
   instance_type               = "${var.front_type}"
   key_name                    = "${var.keypair_name}"
   ebs_optimized               = "${var.front_ebs_optimized}"

--- a/terraform/module-magento/iam.tf
+++ b/terraform/module-magento/iam.tf
@@ -1,54 +1,97 @@
-# data "aws_iam_policy_document" "assume_role" {
-#   statement {
-#     effect = "Allow"
-#
-#     actions = [
-#       "sts:AssumeRole",
-#     ]
-#
-#     principals {
-#       type        = "Service"
-#       identifiers = ["ec2.amazonaws.com"]
-#     }
-#   }
-# }
-#
-# # Create IAM Role for front
-# resource "aws_iam_role" "front" {
-#   name               = "engine-cycloid_${var.env}-front"
-#   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-#   path               = "/${var.project}/"
-# }
-#
-#
-#
-# resource "aws_iam_instance_profile" "front_profile" {
-#   name = "engine-cycloid_profile-front-${var.project}-${var.env}"
-#   role = "${aws_iam_role.front.name}"
-# }
-#
-# # ec2 tag list policy
-# data "aws_iam_policy_document" "ec2-tag-describe" {
-#   statement {
-#     actions = [
-#       "ec2:DescribeTags",
-#     ]
-#
-#     effect    = "Allow"
-#     resources = ["*"]
-#   }
-# }
-#
-# # Global describe tags
-# resource "aws_iam_policy" "ec2-tag-describe" {
-#   name        = "${var.env}-${var.project}-ec2-tag-describe"
-#   path        = "/"
-#   description = "EC2 tags Read only"
-#   policy      = "${data.aws_iam_policy_document.ec2-tag-describe.json}"
-# }
-#
-# resource "aws_iam_policy_attachment" "ec2-tag-describe" {
-#   name       = "${var.env}-${var.project}-ec2-tag-describe"
-#   roles      = ["${aws_iam_role.front.name}"]
-#   policy_arn = "${aws_iam_policy.ec2-tag-describe.arn}"
-# }
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# Create IAM Role for front
+resource "aws_iam_role" "front" {
+  name               = "cycloid_${var.env}-front"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  path               = "/${var.project}/"
+}
+
+resource "aws_iam_instance_profile" "front_profile" {
+  name = "cycloid_profile-front-${var.project}-${var.env}"
+  role = "${aws_iam_role.front.name}"
+}
+
+# ec2 tag list policy
+data "aws_iam_policy_document" "ec2-tag-describe" {
+  statement {
+    actions = [
+      "ec2:DescribeTags",
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ec2-tag-describe" {
+  name        = "${var.env}-${var.project}-ec2-tag-describe"
+  path        = "/"
+  description = "EC2 tags Read only"
+  policy      = "${data.aws_iam_policy_document.ec2-tag-describe.json}"
+}
+
+resource "aws_iam_policy_attachment" "ec2-tag-describe" {
+  name       = "${var.env}-${var.project}-ec2-tag-describe"
+  roles      = ["${aws_iam_role.front.name}"]
+  policy_arn = "${aws_iam_policy.ec2-tag-describe.arn}"
+}
+
+#####################
+# Logs
+data "aws_iam_policy_document" "push-logs" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "logs:ListTagsLogGroup",
+      "logs:DescribeLogGroups",
+      "logs:UntagLogGroup",
+      "logs:DescribeLogStreams",
+      "logs:DescribeSubscriptionFilters",
+      "logs:DescribeMetricFilters",
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "logs:TagLogGroup",
+      "logs:DeleteRetentionPolicy",
+      "logs:PutRetentionPolicy"
+    ]
+    resources = ["arn": "arn:aws:logs:*:*:log-group:${var.project}_${var.env}"]
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = [
+      "logs:DescribeExportTasks",
+      "logs:TestMetricFilter",
+      "logs:CreateLogGroup",
+      "logs:DescribeResourcePolicies",
+      "logs:DescribeDestinations"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "push-logs" {
+  name        = "${var.env}-${var.project}-push-logs"
+  path        = "/"
+  description = "Push log to cloudwatch"
+  policy      = "${data.aws_iam_policy_document.push-logs.json}"
+}
+
+resource "aws_iam_policy_attachment" "push-logs" {
+  name       = "${var.env}-${var.project}-push-logs"
+  roles      = ["${aws_iam_role.front.name}"]
+  policy_arn = "${aws_iam_policy.push-logs.arn}"
+}


### PR DESCRIPTION
This commit add the default system files logs for the magento stack.
It doesn't include the default magento files and vhost to watch (as vhost and file names can change or may not be necessary to log).

We also create by default a dedicated role for the instance created in order to be able to push the logs to cloudwatch