### PR TITLE
cycloid: Adding technologies to the stack description

### DIFF
--- a/.cycloid.yml
+++ b/.cycloid.yml
@@ -7,6 +7,17 @@ keywords:
 author: 'Cycloid'
 image: 'https://raw.githubusercontent.com/cycloid-community-catalog/stack-magento/master/icon.png'
 type: 'stack'
+technologies:
+  - technology: Debian
+    version: 9.x
+  - technology: Nginx
+    version: 1.1x
+  - technology: Php
+    version: 7.2
+  - technology: Redis
+    version: 3.4
+  - technology: Magento
+    version: 2.x
 config:
   # Configuration of the CI pipeline
   pipeline:


### PR DESCRIPTION
This commit add the technologies description in the stack. This stack works well with those versions and are the most common/uptodate.