### PR TITLE
pipeline: fix terraform run_plan > plan_run param

### DIFF
--- a/pipeline/magento.yml
+++ b/pipeline/magento.yml
@@ -198,7 +198,7 @@ jobs:
         - put: tfstate
           params:
             env_name: ((project))-((env))
-            run_plan: true
+            plan_run: true
             terraform_source: merged-stack/
 
   - name: terraform-destroy


### PR DESCRIPTION
It was initially `run_plan`: https://github.com/ljfranklin/terraform-resource/commit/a5a65a476622e9a178aa98f2f2e8bb069a852b44#diff-401b0334e500df466a499f739251c501R16

But got renamed to `plan_run`: https://github.com/ljfranklin/terraform-resource/commit/ebefc368772317337be841650da44c5b011c02e7#diff-401b0334e500df466a499f739251c501L16