### PR TITLE
terraform: depend on aws_cloudwatch_metric_alarm

### DIFF
--- a/terraform/module-magento/front.tf
+++ b/terraform/module-magento/front.tf
@@ -169,8 +169,8 @@ resource "aws_elb" "front" {
 # Cloudwatch Alarms
 
 ###
-
 resource "aws_cloudwatch_metric_alarm" "recover-front" {
+  depends_on          = [aws_instance.front]
   alarm_actions       = ["arn:aws:automate:${var.aws_region}:ec2:recover"]
   alarm_description   = "Recover the instance"
   alarm_name          = "cycloid-engine_recover-${var.project}-front${count.index}-${var.env}"


### PR DESCRIPTION
Fix potential issue after a fail

  on module-magento/front.tf line 181, in resource
"aws_cloudwatch_metric_alarm" "recover-front":
 181:     InstanceId = element(aws_instance.front.*.id, count.index)
    |----------------
    | aws_instance.front is empty tuple
    | count.index is 0

Call to function "element" failed: cannot use element function with an
empty
list.