### PR TITLE
pipeline: add dependency on build job for more visual logic

### DIFF
--- a/pipeline/magento.yml
+++ b/pipeline/magento.yml
@@ -288,6 +288,8 @@ jobs:
         trigger: true
 
       - get: s3_magento-release
+        passed:
+        - build
         trigger: false
 
       - get: git_magento-code
@@ -351,6 +353,8 @@ jobs:
           - full-deploy-front
 
       - get: s3_magento-release
+        passed:
+        - build
         trigger: true
       - get: git_magento-code
         trigger: false


### PR DESCRIPTION
Link build jobs to deployments one to have a more visual dependency